### PR TITLE
bug:  Disable AndroidX Usage in Gradle Properties

### DIFF
--- a/NativeTexturePluginAndroid/gradle.properties
+++ b/NativeTexturePluginAndroid/gradle.properties
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
+android.useAndroidX=false


### PR DESCRIPTION
 This pull request updates the `gradle.properties` file by changing the `android.useAndroidX` property from `true` to `false`. This modification ensures that the project will not use AndroidX libraries. 
Labels: Android, Build, Configuration