### PR TITLE
feat: Disable AndroidX

### DIFF
--- a/NativeTexturePluginAndroid/gradle.properties
+++ b/NativeTexturePluginAndroid/gradle.properties
@@ -14,4 +14,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
-android.useAndroidX=true
+android.useAndroidX=false


### PR DESCRIPTION
 This change disables AndroidX in the NativeTexturePluginAndroid project.

AndroidX is a major improvement to the original Android Support Library. It decouples Android Jetpack libraries from the platform, meaning that developers can update Adopt Jetpack libraries at their own cadence. 
Labels: android, build